### PR TITLE
Fix semantic issues flagged by clang

### DIFF
--- a/SoundplaneLib/SoundplaneDriver.h
+++ b/SoundplaneLib/SoundplaneDriver.h
@@ -88,22 +88,22 @@ extern const char* kSoundplaneAName;
 
 // USB device requests and indexes
 //
-typedef enum MLSoundplaneUSBRequest
+typedef enum
 {
 	kRequestStatus = 0,
 	kRequestMask = 1,
 	kRequestCarriers = 2
-};
+} MLSoundplaneUSBRequest;
 
-typedef enum MLSoundplaneUSBRequestIndex
+typedef enum
 {
 	kRequestCarriersIndex = 0,
 	kRequestMaskIndex = 1
-};
+} MLSoundplaneUSBRequestIndex;
 
 // device states
 //
-typedef enum MLSoundplaneState
+typedef enum
 {
 	kNoDevice = 0,
 	kDeviceConnected = 1,
@@ -111,16 +111,16 @@ typedef enum MLSoundplaneState
 	kDeviceIsTerminating = 3,
 	kDeviceSuspend = 4,
 	kDeviceResume = 5
-};
+} MLSoundplaneState;
 
 // device states
 //
-typedef enum MLSoundplaneErrorType
+typedef enum
 {
 	kDevNoErr = 0,
 	kDevDataDiffTooLarge = 1,
 	kDevGapInSequence = 2
-};
+} MLSoundplaneErrorType;
 
 void K1_unpack_float2(unsigned char *pSrc0, unsigned char *pSrc1, float *pDest);
 	

--- a/Source/TouchTracker.h
+++ b/Source/TouchTracker.h
@@ -49,14 +49,14 @@ const int kTouchReleaseFrames = 100;
 const int kAttackFrames = 100;
 const int kMaxPeaksPerFrame = 4;
 
-typedef enum KeyboardTypes
+typedef enum
 {
 	rectangularA = 0,
 	hexagonalA // etc. 
-};
+} KeyboardTypes;
 
 const int kTouchWidth = 8; // 8 columns in touch data: [x, y, z, dz, age, dt, note, ?] for each touch.
-typedef enum TouchSignalColumns
+typedef enum
 {
 	xColumn = 0,
 	yColumn = 1,
@@ -66,7 +66,7 @@ typedef enum TouchSignalColumns
 	dtColumn = 5,
 	noteColumn = 6,
 	reservedColumn = 7
-};
+} TouchSignalColumns;
 
 class Touch
 {
@@ -103,7 +103,7 @@ public:
 	public:
 		Listener() {}
 		virtual ~Listener() {}
-		virtual void hasNewCalibration(const MLSignal& cal, const MLSignal& cal, float avg) = 0;
+		virtual void hasNewCalibration(const MLSignal& cal, const MLSignal& norm, float avg) = 0;
 	};
 	
 	class Calibrator


### PR DESCRIPTION
The following changes address semantic issues flagged by clang with built with Apple LLVM 5.0 against the 10.9 SDK (Xcode 5 on Mavericks).
