### PR TITLE
Remove CODE_SIGN_IDENTITY from the Xcode project

### DIFF
--- a/Builds/MacOSX/Soundplane.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/Soundplane.xcodeproj/project.pbxproj
@@ -1162,7 +1162,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer: Randy Jones (X494RZB5UA)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
@@ -1222,7 +1221,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer: Randy Jones (X494RZB5UA)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
@@ -1282,7 +1280,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer: Randy Jones (X494RZB5UA)";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				EXCLUDED_SOURCE_FILE_NAMES = "";


### PR DESCRIPTION
It is Randy's own and others can't build without changing or removing this configuration field.

Instead of having it checked in in the Xcode project, a file `release.xcconfig` could be created with the following contents:

```
CODE_SIGN_IDENTITY = Mac Developer: Randy Jones (X494RZB5UA)
```

When developing locally, you can use Xcode as usual, you don't need your code signing identity in that case. When you're about to create a release build, you can make one with the following command:

```
xcodebuild -project Soundplane.xcodeproj -target Soundplane -configuration Release -xcconfig release.xcconfig
```