### PR TITLE
fix compile issues - arm

### DIFF
--- a/Source/SoundplaneApp.cpp
+++ b/Source/SoundplaneApp.cpp
@@ -76,7 +76,7 @@ void SoundplaneApp::initialise (const String& commandLine)
 
 
   startTimer(ml::Timers::kMillisecondsResolution);
-  theTimers.start(true);
+  theTimers->start(true);
   MLConsole() << "Starting Soundplane v." << MLProjectInfo::versionString << "...\n";
 }
 

--- a/Source/SoundplaneApp.cpp
+++ b/Source/SoundplaneApp.cpp
@@ -5,6 +5,7 @@
 
 #include "SoundplaneApp.h"
 
+
 SoundplaneApp::SoundplaneApp()
 {
 }
@@ -73,9 +74,10 @@ void SoundplaneApp::initialise (const String& commandLine)
 	mpController->fetchAllProperties();
 	mpView->goToPage(0);
 
-  startTimer(ml::Timers::kMillisecondsResolution);
-  MLConsole() << "Starting Soundplane v." << MLProjectInfo::versionString << "...\n";
 
+  startTimer(ml::Timers::kMillisecondsResolution);
+  theTimers.start(true);
+  MLConsole() << "Starting Soundplane v." << MLProjectInfo::versionString << "...\n";
 }
 
 void SoundplaneApp::shutdown()

--- a/Source/SoundplaneApp.h
+++ b/Source/SoundplaneApp.h
@@ -27,9 +27,7 @@ public:
 
   void timerCallback()
   {
-    ml::Timers &t = theTimers;
-      // ml::Timers &t = ml::Timers::theTimers();
-    // t.tick();
+    theTimers->tick();
   }
 
   // real init and shutdown should be done here, according to JUCE docs
@@ -63,8 +61,7 @@ private:
   std::unique_ptr<MLAppState> mpModelState;
   std::unique_ptr<MLAppState> mpViewState;
 
-  ml::Timers theTimers;
-
+  ml::SharedResourcePointer<ml::Timers> theTimers;
 };
 
 // This macro creates the application's main() function.

--- a/Source/SoundplaneApp.h
+++ b/Source/SoundplaneApp.h
@@ -27,8 +27,9 @@ public:
 
   void timerCallback()
   {
-    ml::Timers &t = ml::Timers::theTimers();
-    t.tick();
+    ml::Timers &t = theTimers;
+      // ml::Timers &t = ml::Timers::theTimers();
+    // t.tick();
   }
 
   // real init and shutdown should be done here, according to JUCE docs
@@ -61,6 +62,8 @@ private:
 
   std::unique_ptr<MLAppState> mpModelState;
   std::unique_ptr<MLAppState> mpViewState;
+
+  ml::Timers theTimers;
 
 };
 

--- a/ml-juce/JuceLookAndFeel/MLDial.cpp
+++ b/ml-juce/JuceLookAndFeel/MLDial.cpp
@@ -1180,7 +1180,7 @@ void MLDial::restoreMouseIfHidden()
         for (int i = Desktop::getInstance().getNumMouseSources(); --i >= 0;)
             Desktop::getInstance().getMouseSource(i)->enableUnboundedMouseMovement (false);
 
-        Point<int> mousePos;
+        juce::Point<int> mousePos;
 		mousePos = Desktop::getLastMouseDownPosition();
         Desktop::setMousePosition (mousePos);
     }

--- a/ml-juce/JuceLookAndFeel/MLLookAndFeel.cpp
+++ b/ml-juce/JuceLookAndFeel/MLLookAndFeel.cpp
@@ -2051,8 +2051,8 @@ void MLLookAndFeel::setBackgroundGradient(Graphics& g, MLRect bounds, MLRect bor
 	if (mGradientMode < 2)
 	{
 		ColourGradient cg;
-		cg.point1 = Point<float>(0, borderRect.top());
-		cg.point2 = Point<float>(0, borderRect.bottom());
+		cg.point1 = juce::Point<float>(0, borderRect.top());
+		cg.point2 = juce::Point<float>(0, borderRect.bottom());
 		cg.isRadial = false;
 		switch(mGradientMode)
 		{

--- a/ml-juce/JuceLookAndFeel/MLMultiButton.cpp
+++ b/ml-juce/JuceLookAndFeel/MLMultiButton.cpp
@@ -174,7 +174,7 @@ void MLMultiButton::mouseExit (const MouseEvent& )
 // change state of all buttons under drag to match first button clicked, after click.
 void MLMultiButton::mouseDrag(const MouseEvent& e)
 {
-	int b = getButtonUnderPoint(Point<int>(e.x, e.y));
+	int b = getButtonUnderPoint(juce::Point<int>(e.x, e.y));
 	
     if (isEnabled())
     {		
@@ -209,7 +209,7 @@ void MLMultiButton::mouseDrag(const MouseEvent& e)
     }
 }
 
-int MLMultiButton::getButtonUnderPoint(const Point<int>& p)
+int MLMultiButton::getButtonUnderPoint(const juce::Point<int>& p)
 {
 	return mPos.getElementUnderPoint(Vec2(p.getX(), p.getY()));
 }

--- a/ml-juce/JuceLookAndFeel/MLMultiButton.h
+++ b/ml-juce/JuceLookAndFeel/MLMultiButton.h
@@ -53,7 +53,7 @@ public:
 	void resizeWidget(const MLRect& b, const int );
 
 private:
-	int getButtonUnderPoint(const Point<int>& p);
+	int getButtonUnderPoint(const juce::Point<int>& p);
 	int getButtonUnderMouse();
 
 	int mNumButtons;

--- a/ml-juce/JuceLookAndFeel/MLUI.h
+++ b/ml-juce/JuceLookAndFeel/MLUI.h
@@ -76,16 +76,16 @@ const int kMLTreeViewItemSize = 15;
 
 inline juce::Rectangle<float> MLToJuceRect(const MLRect& b) { return juce::Rectangle<float>(b.left(), b.top(), b.width(), b.height()); }
 inline juce::Rectangle<int> MLToJuceRectInt(const MLRect& b) { return juce::Rectangle<int>(b.left(), b.top(), b.width(), b.height()); }
-inline Point<float> MLToJucePoint(const Vec2& b) { return Point<float>(b.x(), b.y()); }
+inline juce::Point<float> MLToJucePoint(const Vec2& b) { return juce::Point<float>(b.x(), b.y()); }
 	
 inline MLRect juceToMLRect(const juce::Rectangle<int>& b) { return MLRect(b.getX(), b.getY(), b.getWidth(), b.getHeight()); }
 inline MLRect juceToMLRect(const juce::Rectangle<float>& b) { return MLRect(b.getX(), b.getY(), b.getWidth(), b.getHeight()); }
-inline MLPoint juceToMLPoint(const Point<int>& b) { return MLPoint(b.getX(), b.getY()); }
-inline MLPoint juceToMLPoint(const Point<float>& b) { return MLPoint(b.getX(), b.getY()); }
+inline MLPoint juceToMLPoint(const juce::Point<int>& b) { return MLPoint(b.getX(), b.getY()); }
+inline MLPoint juceToMLPoint(const juce::Point<float>& b) { return MLPoint(b.getX(), b.getY()); }
 
 MLPoint getPixelCenter(const MLRect& r);
 
-inline MLPoint floatPointToInt(Point<float> fp)
+inline MLPoint floatPointToInt(juce::Point<float> fp)
 {
 	return(MLPoint(fp.getX(), fp.getY()));
 }

--- a/ml-juce/deprecated/MLDSPDeprecated.h
+++ b/ml-juce/deprecated/MLDSPDeprecated.h
@@ -10,7 +10,7 @@
 
 #include "MLProc.h"
 #include "MLMatrix.h"
-#include "MLScalarMath.h"
+#include "MLDSPScalarMath.h"
 using namespace ml;
 
 #include <cassert>

--- a/ml-juce/deprecated/MLScale.h
+++ b/ml-juce/deprecated/MLScale.h
@@ -12,7 +12,7 @@
 #include <array>
 #include <cmath>
 
-#include "MLScalarMath.h"
+#include "MLDSPScalarMath.h"
 
 //#include "MLText.h"
 

--- a/ml-juce/deprecated/MLVectorDeprecated.h
+++ b/ml-juce/deprecated/MLVectorDeprecated.h
@@ -12,7 +12,7 @@
 // of MLSignals would be too big. 
 
 //#include "mldsp.h"
-#include "MLScalarMath.h"
+#include "MLDSPScalarMath.h"
 #include <cmath>
 #include <algorithm>
 


### PR DESCRIPTION
fixes issues when trying to build on latest xcode and madronalib

a) Point ->juce::Point
b) MLScalarMath.h -> MLDSPScalarMath.h"
c) no mlTimers:theTimers

for (c) I assume the idea is SoundplaneApp should now create a timers object, then call start on it
please review my change in SoundplaneApp.h/cpp for this, as it was a little unclear to me new behaviour of MLTimers


However, whilst this compiles the UI is still not 'correct', its not updating correctly 
perhaps mlTimers is wrong? (but I am seeing callbacks) 
though Im also seeing alot of the folllowing warnings...

/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gl.h:5:2: warning: gl.h and gl3.h are both
      included. Compiler will not invoke errors if using removed OpenGL functionality. [-W#warnings]
#warning gl.h and gl3.h are both included.  Compiler will not invoke errors if using removed OpenGL functionality.

note: the ui is just refreshing, it seems to be functioning.

if I set midi active, and use a midi monitor ... the midi messages are looking garbled.
(Ive not checked osc yet) 













